### PR TITLE
5636

### DIFF
--- a/sites/all/themes/scratchpads/template.php
+++ b/sites/all/themes/scratchpads/template.php
@@ -378,6 +378,15 @@ function scratchpads_preprocess_page(&$vars){
   if(isset($vars['tabs']) && empty($vars['tabs']['#primary'])){
     $vars['tabs'] = array();
   }
+  if (isset($vars['page']['content']['content']['content']['system_main']['term_heading']['term']['description_field']['#object'])) {
+    $term = $vars['page']['content']['content']['content']['system_main']['term_heading']['term']['description_field']['#object'];
+    if (isset($term->vid)) {
+      $lexicon_vids = variable_get("lexicon_vids");
+      if (isset($lexicon_vids[$term->vid]) && $lexicon_vids[$term->vid] > 0) {
+        $vars['page']['content']['content']['content']['system_main']['no_content']['#markup'] = '';
+      }
+    }
+  }
 }
 
 /**

--- a/sites/all/themes/scratchpads/template.php
+++ b/sites/all/themes/scratchpads/template.php
@@ -378,6 +378,7 @@ function scratchpads_preprocess_page(&$vars){
   if(isset($vars['tabs']) && empty($vars['tabs']['#primary'])){
     $vars['tabs'] = array();
   }
+  //Hide no content on lexicon pages
   if (isset($vars['page']['content']['content']['content']['system_main']['term_heading']['term']['description_field']['#object'])) {
     $term = $vars['page']['content']['content']['content']['system_main']['term_heading']['term']['description_field']['#object'];
     if (isset($term->vid)) {


### PR DESCRIPTION
@benscott this seems messy

It's based on this: https://www.drupal.org/forum/support/theme-development/2012-01-03/how-to-remove-there-is-currently-no-content-classified

Is there a tidier way?