### PR TITLE
Strip the tags from page titles

### DIFF
--- a/sites/all/themes/scratchpads/templates/html.tpl.php
+++ b/sites/all/themes/scratchpads/templates/html.tpl.php
@@ -2,7 +2,7 @@
 <html lang="<?php print $language->language; ?>" dir="<?php print $language->dir; ?>"<?php print $rdf->version . $rdf->namespaces; ?>>
 <head<?php print $rdf->profile; ?>>
   <?php print $head; ?>
-  <title><?php print $head_title; ?></title>  
+  <title><?php print strip_tags($head_title); ?></title>
   <?php print $styles; ?>
   <?php print $scripts; ?>
   <!--[if lt IE 9]><script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script><![endif]-->


### PR DESCRIPTION
They should never be rendered in the title.

Fixes: https://github.com/NaturalHistoryMuseum/scratchpads2/issues/5724