### PR TITLE
Add tifs to the allowed extension types

### DIFF
--- a/sites/all/modules/custom/scratchpads/scratchpads_media_gallery/scratchpads_media_gallery.install
+++ b/sites/all/modules/custom/scratchpads/scratchpads_media_gallery/scratchpads_media_gallery.install
@@ -537,3 +537,17 @@ function scratchpads_media_gallery_update_7020(){
     }
   }
 }
+
+/**
+ * Update the extensions allowed to include tif.
+ */
+function scratchpads_media_gallery_update_7021(){
+  $media = field_info_field('field_media');
+  foreach($media['bundles'] as $entity_type => $bundles){
+    foreach($bundles as $bundle_name){
+      $instance = field_info_instance($entity_type, 'field_media', $bundle_name);
+      $instance['settings']['file_extensions'] = FIELD_MEDIA_FILE_EXTENSIONS;
+      field_update_instance($instance);
+    }
+  }
+}

--- a/sites/all/modules/custom/scratchpads/scratchpads_media_gallery/scratchpads_media_gallery.module
+++ b/sites/all/modules/custom/scratchpads/scratchpads_media_gallery/scratchpads_media_gallery.module
@@ -1,6 +1,6 @@
 <?php
 // DEFINE the file extensions that we allow.
-DEFINE('FIELD_MEDIA_FILE_EXTENSIONS', 'svg tiff jpg jpeg gif png txt doc docx xls xlsx pdf ppt pptx pps ppsx odt ods odp mp3 mov mp4 m4a m4v mpeg avi ogg oga ogv wmv ico xml nex phy nhx zip gz kmz');
+DEFINE('FIELD_MEDIA_FILE_EXTENSIONS', 'svg tif tiff jpg jpeg gif png txt doc docx xls xlsx pdf ppt pptx pps ppsx odt ods odp mp3 mov mp4 m4a m4v mpeg avi ogg oga ogv wmv ico xml nex phy nhx zip gz kmz');
 include_once ('scratchpads_media_gallery.features.inc');
 
 /**


### PR DESCRIPTION
This change also includes an update to actually make the change available.

Fixes: https://github.com/NaturalHistoryMuseum/scratchpads2/issues/5757