### PR TITLE
Remove print_r line that was breaking ajax calls

### DIFF
--- a/sites/all/modules/custom/wavesurfer/wavesurfer.module
+++ b/sites/all/modules/custom/wavesurfer/wavesurfer.module
@@ -164,8 +164,6 @@ function theme_wavesurfer_waveform($variables){
   $parts = explode("/", current_path());
   if ($parts[0] == "node") {
     $cloud_url = "https://ams3.digitaloceanspaces.com/bioacoustica-analysis/flac/".$parts[1].".flac";
-  } else {
-    print_r($parts);
   }
   if (false  === file_get_contents($cloud_url,0,null,0,1)) {
     $cloud_url = NULL;


### PR DESCRIPTION
This print_r was adding extra data to the end of a valid JSON response from the server back to the client when making an ajax request. This resulted in the client failing to parse the JSON and erroring.