### PR TITLE
Changes the display of `.stripy-div-group` to table

### DIFF
--- a/sites/all/themes/scratchpads/css/global.css
+++ b/sites/all/themes/scratchpads/css/global.css
@@ -622,6 +622,8 @@ h1.site-name,h2.site-name {
 .stripy-div-group {
   margin: 20px 0;
   border-top: 1px solid #D9DADD;
+  display: table;
+  border-collapse: collapse;
 }
 
 .stripy-div-group:empty{
@@ -633,6 +635,16 @@ h1.site-name,h2.site-name {
   border-color: #D9DADD;
   border-style: none solid solid solid;
   clear: left;
+  display: table-row;
+}
+
+.stripy-div-group .field > div {
+  display: table-cell;
+  padding: 5px 5px 10px;
+}
+
+.stripy-div-group .field > div p {
+  margin-bottom: 0;
 }
 
 .stripy-div-group .odd {
@@ -640,15 +652,9 @@ h1.site-name,h2.site-name {
 }
 
 .stripy-div-group .field-label {
-  float: left;
   width: 200px;
   text-align: right;
-  padding-right: 5px;
   font-weight: bold;
-}
-
-.stripy-div-group .field-label,.stripy-div-group .field-items {
-  padding: 6px 0;
 }
 
 .stripy-div-group .field-items {
@@ -657,7 +663,6 @@ h1.site-name,h2.site-name {
 
 .stripy-div-group .field-items {
   border-left: 1px solid #D9DADD;
-  padding-left: 5px;
 }
 
 .node div.item-list ul li {


### PR DESCRIPTION
Floating divs were not resizing the rows correctly, leading to overlapping borders.
Also some minor padding tweaks. Fixes #5774