### PR TITLE
Remove the float: left; property on .progress-disabled

### DIFF
--- a/sites/all/themes/tao/drupal.css
+++ b/sites/all/themes/tao/drupal.css
@@ -280,7 +280,6 @@ html.js .no-js { display:none; }
   }
 
 .progress .percentage { float:right; }
-.progress-disabled { float:left; }
 .ahah-progress { float:left; }
 
 .ahah-progress .throbber {


### PR DESCRIPTION
was causing the upload button to jump to the left temporarily while media uploads were in progress.
fixes #5710