### PR TITLE
Add <xml> tags to the biblio title when validating

### DIFF
--- a/sites/all/modules/custom/scratchpads/scratchpads_biblio/scratchpads_biblio.module
+++ b/sites/all/modules/custom/scratchpads/scratchpads_biblio/scratchpads_biblio.module
@@ -23,7 +23,8 @@ function scratchpads_biblio_form_node_form_validate(&$form, &$form_state)
   $title = $form_state['values']['title'];
   if (strpos($title, '<') !== false) {
     libxml_use_internal_errors(true);
-    $doc = simplexml_load_string($title);
+    $xmlString = "<xml>$title</xml>";
+    $doc = simplexml_load_string($xmlString);
     $errors = libxml_get_errors();
     if (!$doc || $errors) {
       form_set_error('title', t('Invalid HTML'));


### PR DESCRIPTION
simplexml does not recognise the string as being well-formed unless there is a root node, so temporarily adding <xml> tags allows it to check the rest of the title for well-formed html.

fixes #5872 and #5896.