### PR TITLE
Add a 'gridless' class for non-view blocks in the main content block

### DIFF
--- a/sites/all/themes/scratchpads/css/global.css
+++ b/sites/all/themes/scratchpads/css/global.css
@@ -573,6 +573,12 @@ h1.site-name,h2.site-name {
   margin-bottom: 25px;
 }
 
+/* For content blocks without grid-[0-9] */
+#region-content .block.gridless {
+  float: left;
+  width: 100%;
+}
+
 /************************ MEDIA GALLERY *********************/
 .view-species-media .view-content ul {
   list-style: none;

--- a/sites/all/themes/scratchpads/template.php
+++ b/sites/all/themes/scratchpads/template.php
@@ -8,7 +8,7 @@
  * @param array $data
  */
 function scratchpads_block_view_alter(&$data, $block){
-  if(isset($data['content']) && $block->module == 'views'){
+  if(isset($data['content']) && ($block->module == 'views' || $block->region == 'content')){
     // Move the view classes to the block classes
     if(preg_match('/(grid-[0-9])/', $data['content']['#markup'], $matches)){
       if(count($matches)){
@@ -26,6 +26,9 @@ function scratchpads_block_view_alter(&$data, $block){
         }
         $data['class'] = $classes;
       }
+    }
+    else {
+      $data['class'] = array('gridless');
     }
   }
 }


### PR DESCRIPTION
Without the `float: left;` property the blocks do not interact with the other `.grid-[0-9]` classes correctly.

Fixes #5892 