### PR TITLE
Custom block visibility and titles

### DIFF
--- a/sites/all/modules/custom/scratchpads/scratchpads_front/scratchpads_front.module
+++ b/sites/all/modules/custom/scratchpads/scratchpads_front/scratchpads_front.module
@@ -185,6 +185,9 @@ function scratchpads_front_views_pre_view(&$view, &$display_id, &$args){
         );
         $view->display_handler->set_option('empty', $empty_area_options);
       }
+      if (isset($custom_block->title) && $custom_block->title != ''){
+        $view->title = $custom_block->title;
+      }
       $view->args[] = scratchpads_front_variable_get($var);
       break;
     case 'front_page_slideshow':

--- a/sites/all/modules/custom/scratchpads/scratchpads_front/scratchpads_front.module
+++ b/sites/all/modules/custom/scratchpads/scratchpads_front/scratchpads_front.module
@@ -185,8 +185,8 @@ function scratchpads_front_views_pre_view(&$view, &$display_id, &$args){
         );
         $view->display_handler->set_option('empty', $empty_area_options);
       }
-      if (isset($custom_block->title) && $custom_block->title != ''){
-        $view->title = $custom_block->title;
+      if (isset($custom_block->subject) && $custom_block->subject != ''){
+        $view->title = $custom_block->subject;
       }
       $view->args[] = scratchpads_front_variable_get($var);
       break;

--- a/sites/all/modules/custom/scratchpads/scratchpads_front/scratchpads_front.module
+++ b/sites/all/modules/custom/scratchpads/scratchpads_front/scratchpads_front.module
@@ -516,6 +516,8 @@ function scratchpads_front_page_edit_submit($form, &$form_state){
   $form_state['redirect'] = '<front>';
   // Clear the views cache, as the slideshow view is dynamic
   views_invalidate_cache();
+  // clear the other caches so the blocks update
+  drupal_flush_all_caches();
 }
 
 /*********************************************************************************************

--- a/sites/all/modules/custom/scratchpads/scratchpads_tweaks/scratchpads_tweaks.module
+++ b/sites/all/modules/custom/scratchpads/scratchpads_tweaks/scratchpads_tweaks.module
@@ -831,3 +831,14 @@ function scratchpads_tweaks_preprocess_status_report(&$variables) {
     }
   }
 }
+
+/**
+ * Implements hook_views_post_build()
+ */
+function scratchpads_tweaks_views_post_build(&$view) {
+  // if a view has an override title set, use that instead of the build title (e.g. 'Recent %s')
+  // Useful for custom blocks
+  if (isset($view->title)){
+    $view->build_info['title'] = $view->title;
+  }
+}


### PR DESCRIPTION
- allow custom blocks to set titles
- flush caches on saving the home page to ensure updated blocks show up straight away

fixes #5895 