### PR TITLE
Allow configuration of species tabs

### DIFF
--- a/sites/all/modules/custom/scratchpads/scratchpads_species/scratchpads_species.module
+++ b/sites/all/modules/custom/scratchpads/scratchpads_species/scratchpads_species.module
@@ -110,7 +110,7 @@ function scratchpads_species_module_implements_alter(&$implementations, $hook){
  *             the user on the page.
  * @return string
  */
-function get_species_tab_form_name($tab) {
+function _scratchpads_species_get_species_tab_form_name($tab) {
   return "show_{$tab}_tab";
 }
 
@@ -160,7 +160,7 @@ function scratchpads_species_form_taxonomy_form_vocabulary_alter(&$form, &$form_
 
     // loop through each of the default tabs, creating a checkbox for each
     foreach (scratchpads_species_get_default_tabs() as $tab => $tab_name) {
-      $tab_field_name = get_species_tab_form_name($tab);
+      $tab_field_name = _scratchpads_species_get_species_tab_form_name($tab);
       // extract the current enabled value for the tab, if there is one
       if (isset($form['#vocabulary']->$tab_field_name)) {
         $current_value = $form['#vocabulary']->$tab_field_name;
@@ -205,7 +205,7 @@ function scratchpads_species_contextual_links_view_alter(&$element, $items){
  *
  * @param $vocabulary the vocabulary object
  */
-function upsert_vocabulary_variables($vocabulary) {
+function _scratchpads_species_upsert_vocabulary_variables($vocabulary) {
   $show_syns = variable_get('scratchpads_species_display_synonyms', array());
   if(!empty($vocabulary->show_synonym_data)){
     $show_syns[$vocabulary->vid] = $vocabulary->vid;
@@ -220,7 +220,7 @@ function upsert_vocabulary_variables($vocabulary) {
   $enabled_species_tabs[$vocabulary->vid] = array();
   // loop through the default tabs and set their enabled state in the array
   foreach (array_keys(scratchpads_species_get_default_tabs()) as $tab) {
-    $enabled_species_tabs[$vocabulary->vid][$tab] = $vocabulary->{get_species_tab_form_name($tab)};
+    $enabled_species_tabs[$vocabulary->vid][$tab] = $vocabulary->{_scratchpads_species_get_species_tab_form_name($tab)};
   }
   // save the data
   variable_set('scratchpads_species_enabled_tabs', $enabled_species_tabs);
@@ -230,14 +230,14 @@ function upsert_vocabulary_variables($vocabulary) {
  * Implements hook_taxonomy_vocabulary_insert().
  */
 function scratchpads_species_taxonomy_vocabulary_insert($vocabulary){
-  upsert_vocabulary_variables($vocabulary);
+  _scratchpads_species_upsert_vocabulary_variables($vocabulary);
 }
 
 /**
  * Implements hook_taxonomy_vocabulary_update().
  */
 function scratchpads_species_taxonomy_vocabulary_update($vocabulary){
-  upsert_vocabulary_variables($vocabulary);
+  _scratchpads_species_upsert_vocabulary_variables($vocabulary);
 }
 
 /**
@@ -259,7 +259,7 @@ function scratchpads_species_taxonomy_vocabulary_load($vocabularies){
   foreach ($enabled_species_tabs as $vid => $tabs) {
     foreach ($tabs as $tab => $enabled) {
       // set the enabled states for each tab on the vocabulary
-      $vocabularies[$vid]->{get_species_tab_form_name($tab)} = $enabled;
+      $vocabularies[$vid]->{_scratchpads_species_get_species_tab_form_name($tab)} = $enabled;
     }
   }
 }
@@ -269,7 +269,7 @@ function scratchpads_species_taxonomy_vocabulary_load($vocabularies){
  */
 function scratchpads_species_taxonomy_vocabulary_delete($vocabulary){
   $vocabulary->show_synonym_data = FALSE;
-  upsert_vocabulary_variables($vocabulary);
+  _scratchpads_species_upsert_vocabulary_variables($vocabulary);
 
   // clear out the data from our "scratchpads_species_enabled_tabs" variable (if needed)
   $enabled_species_tabs = variable_get('scratchpads_species_enabled_tabs', array());

--- a/sites/all/modules/custom/scratchpads/scratchpads_species/scratchpads_species.module
+++ b/sites/all/modules/custom/scratchpads/scratchpads_species/scratchpads_species.module
@@ -104,6 +104,17 @@ function scratchpads_species_module_implements_alter(&$implementations, $hook){
 }
 
 /**
+ * Returns the attribute name of the given tab on the vocabulary form object.
+ * 
+ * @param $tab the tab identifier, this should be the identifier for the tab, not the name shown to
+ *             the user on the page.
+ * @return string
+ */
+function get_species_tab_form_name($tab) {
+  return "show_{$tab}_tab";
+}
+
+/**
  * Implements hook_form_FORM_ID_alter().
  */
 function scratchpads_species_form_taxonomy_form_vocabulary_alter(&$form, &$form_state, $form_id){
@@ -125,6 +136,48 @@ function scratchpads_species_form_taxonomy_form_vocabulary_alter(&$form, &$form_
         )
       )
     );
+
+    // create a settings section for the species tab display options
+    $form['scratchpads_species_display'] = array(
+      // this is required to ensure the #states bit works for this fieldset, without this id it
+      // mysteriously doesn't (https://www.drupal.org/project/drupal/issues/767212#comment-11270515)
+      '#id' => 'scratchpads_species_display',
+      '#type' => 'fieldset',
+      '#title' => t('Species page tab display options'),
+      '#description' => t('Modify which species tabs by default are shown for this vocabulary.'),
+      // weight it at 3 so that it shows below the 2 weight the simple_taxonomy_display section has
+      '#weight' => 3,
+      '#states' => array(
+        // this fieldset should be invisible if the vocabulary is not a biological classification or
+        // if the "use_scratchpads_species_pages" setting is unchecked
+        'invisible' => array(
+          array(':input[name="biological_classification"]' => array('value' => '')),
+          'OR',
+          array(':input[name="use_scratchpads_species_pages"]' => array('checked' => false))
+        )
+      )
+    );
+
+    // loop through each of the default tabs, creating a checkbox for each
+    foreach (scratchpads_species_get_default_tabs() as $tab => $tab_name) {
+      $tab_field_name = get_species_tab_form_name($tab);
+      // extract the current enabled value for the tab, if there is one
+      if (isset($form['#vocabulary']->$tab_field_name)) {
+        $current_value = $form['#vocabulary']->$tab_field_name;
+      } else {
+        // default to true if there is not current value for the tab
+        $current_value = true;
+      }
+
+      // actually add the checkbox
+      $form['scratchpads_species_display'][$tab_field_name] = array(
+        '#title' => t("Show {$tab_name} tab on species pages."),
+        '#description' => t("Check this box to display the {$tab_name} tab on Scratchpads species
+                             pages. Most users should leave this box checked."),
+        '#type' => 'checkbox',
+        '#default_value' => $current_value,
+      );
+    }
   }
 }
 
@@ -158,6 +211,17 @@ function scratchpads_species_taxonomy_vocabulary_insert($vocabulary){
     unset($show_syns[$vocabulary->vid]);
   }
   variable_set('scratchpads_species_display_synonyms', $show_syns);
+
+  // retrieve the current tab enabled settings
+  $enabled_species_tabs = variable_get('scratchpads_species_enabled_tabs', array());
+  // reset the settings for this specific vocabulary (we're going to just completely overwrite them)
+  $enabled_species_tabs[$vocabulary->vid] = array();
+  // loop through the default tabs and set their enabled state in the array
+  foreach (array_keys(scratchpads_species_get_default_tabs()) as $tab) {
+    $enabled_species_tabs[$vocabulary->vid][$tab] = $vocabulary->{get_species_tab_form_name($tab)};
+  }
+  // save the data
+  variable_set('scratchpads_species_enabled_tabs', $enabled_species_tabs);
 }
 
 /**
@@ -180,6 +244,15 @@ function scratchpads_species_taxonomy_vocabulary_load($vocabularies){
       $vocabularies[$vid]->show_synonym_data = $vid;
     }
   }
+
+  // retrieve the current tab enabled settings
+  $enabled_species_tabs = variable_get('scratchpads_species_enabled_tabs', array());
+  foreach ($enabled_species_tabs as $vid => $tabs) {
+    foreach ($tabs as $tab => $enabled) {
+      // set the enabled states for each tab on the vocabulary
+      $vocabularies[$vid]->{get_species_tab_form_name($tab)} = $enabled;
+    }
+  }
 }
 
 /**
@@ -188,6 +261,13 @@ function scratchpads_species_taxonomy_vocabulary_load($vocabularies){
 function scratchpads_species_taxonomy_vocabulary_delete($vocabulary){
   $vocabulary->show_synonym_data = FALSE;
   scratchpads_species_taxonomy_vocabulary_insert($vocabulary);
+
+  // clear out the data from our "scratchpads_species_enabled_tabs" variable (if needed)
+  $enabled_species_tabs = variable_get('scratchpads_species_enabled_tabs', array());
+  if (isset($enabled_species_tabs[$vocabulary->vid])) {
+    unset($enabled_species_tabs[$vocabulary->vid]);
+  }
+  variable_set('scratchpads_species_enabled_tabs', $enabled_species_tabs);
 }
 
 /**
@@ -286,6 +366,18 @@ function scratchpads_species_title_callback($term){
  */
 function scratchpads_species_access_callback($term, $op = 'overview'){
   if(scratchpads_species_term_is_biological_classification($term)){
+    // retrieve the tab settings for the vocabulary this term belongs to
+    $enabled_species_tabs = variable_get('scratchpads_species_enabled_tabs', array());
+    if (isset($enabled_species_tabs[$term->vid])) {
+      $tab_settings = $enabled_species_tabs[$term->vid];
+    } else {
+      $tab_settings = array();
+    }
+    // determine whether the tab should be shown using the user configured options
+    if (isset($tab_settings[$op]) and !$tab_settings[$op]) {
+      return false;
+    }
+
     // Always show these tabs
     if(in_array($op, array(
       'overview',

--- a/sites/all/modules/custom/scratchpads/scratchpads_species/scratchpads_species.module
+++ b/sites/all/modules/custom/scratchpads/scratchpads_species/scratchpads_species.module
@@ -201,9 +201,11 @@ function scratchpads_species_contextual_links_view_alter(&$element, $items){
 }
 
 /**
- * Implements hook_taxonomy_vocabulary_insert().
+ * Creates/updates the variables associated with the given vocabulary.
+ *
+ * @param $vocabulary the vocabulary object
  */
-function scratchpads_species_taxonomy_vocabulary_insert($vocabulary){
+function upsert_vocabulary_variables($vocabulary) {
   $show_syns = variable_get('scratchpads_species_display_synonyms', array());
   if(!empty($vocabulary->show_synonym_data)){
     $show_syns[$vocabulary->vid] = $vocabulary->vid;
@@ -225,10 +227,17 @@ function scratchpads_species_taxonomy_vocabulary_insert($vocabulary){
 }
 
 /**
+ * Implements hook_taxonomy_vocabulary_insert().
+ */
+function scratchpads_species_taxonomy_vocabulary_insert($vocabulary){
+  upsert_vocabulary_variables($vocabulary);
+}
+
+/**
  * Implements hook_taxonomy_vocabulary_update().
  */
 function scratchpads_species_taxonomy_vocabulary_update($vocabulary){
-  return scratchpads_species_taxonomy_vocabulary_insert($vocabulary);
+  upsert_vocabulary_variables($vocabulary);
 }
 
 /**
@@ -260,7 +269,7 @@ function scratchpads_species_taxonomy_vocabulary_load($vocabularies){
  */
 function scratchpads_species_taxonomy_vocabulary_delete($vocabulary){
   $vocabulary->show_synonym_data = FALSE;
-  scratchpads_species_taxonomy_vocabulary_insert($vocabulary);
+  upsert_vocabulary_variables($vocabulary);
 
   // clear out the data from our "scratchpads_species_enabled_tabs" variable (if needed)
   $enabled_species_tabs = variable_get('scratchpads_species_enabled_tabs', array());


### PR DESCRIPTION
Adds a set of configuration options for the default tabs that show up on a species/taxon description page. Looks like this:

![Screenshot from 2019-06-14 09-18-33](https://user-images.githubusercontent.com/4718259/59494991-466fba80-8e86-11e9-87f6-fe53683f1056.png)

Closes: https://github.com/NaturalHistoryMuseum/scratchpads2/issues/5947