### PR TITLE
Apply toggle setting on page load

### DIFF
--- a/sites/all/modules/custom/tinytax/js/tinytax.js
+++ b/sites/all/modules/custom/tinytax/js/tinytax.js
@@ -2,6 +2,16 @@
   Drupal.behaviors.tinytax = {attach: function(context, settings){
     if($.cookie('tinytax_toggled') > 0) {
       $('.tinytax-toggle-checkbox').attr('checked', 'checked');
+      // this code ensures the toggle's state has an effect on the tree on page load. First, find
+      // the tinytax direct child of this context (if there is one). This is needed as at least
+      // sometimes, but probably all the time, this attach function gets called twice, firstly with
+      // the whole document as the context and then secondly (after the ajax has completed) with the
+      // actual block as the context. This code looks for an element with the tinytax class as a
+      // child of the context and hence only matches on the second run through. We then apply the
+      // hiding to all "toggleable" elements in this tinytax element.
+      $(context).children('.tinytax').each(function() {
+        $('.toggleable', $(this)).hide();
+      });
     }
     $('.tinytax-toggle-checkbox').change(function(){
       if($(this).attr('checked')) {


### PR DESCRIPTION
If the toggle is checked when selecting a taxa or refreshing the page then the state is not respected and you have to untick the checkbox and then recheck it. This code applies it when the tinytax code is attached.

Note that the code has been implemented in a way that ensures we only alter the elements within the context that have the class toggleable. This follows the rest of the code which makes sure it uses the vid value throughout to only alter the tree it is attached to. This seems like a clear choice though it is not doc'd, however, it goes against the cookie value which is a single cookie for all vids. In the absense of comments explaining this, the code has been written so that it only acts on the tree it is attached to and not all .toggleable elements.

Fixes https://github.com/NaturalHistoryMuseum/scratchpads2/issues/5888