### PR TITLE
Use the SimpleXMLElement constructor's URL fetching abilities instead of drupal_http_request

### DIFF
--- a/sites/all/modules/custom/scratchpads/scratchpads_species/modules/bhl/bhl.module
+++ b/sites/all/modules/custom/scratchpads/scratchpads_species/modules/bhl/bhl.module
@@ -194,21 +194,18 @@ function bhl_contextual_links_view_alter(&$element, $items){
 }
 
 /**
- * Fetches XML from the given URL with the given options. Uses the drupal_http_request function to
- * get the data from the URL. If there are any problems with the request (!200, xml error etc) then
- * this will return false, otherwise returns the SimpleXMLElement object.
+ * Fetches XML from the given URL with the given options. Uses the SimpleXMLElement constructor
+ * function's ability to take a url and fetch the xml from it to get the data from the URL. If there
+ * are any problems with the request (xml error etc) then this will return false, otherwise returns
+ * the SimpleXMLElement object.
  *
  * @param string $url the url to request
- * @param array $options options for the request, default is just timeout: 30.
  * @return bool|SimpleXMLElement false if there was a problem with getting the data from the URL, or
  *                               the SimpleXMLElement object if everything was fine
  */
-function _bhl_fetch_xml($url, $options = array('timeout' => 30)) {
+function _bhl_fetch_xml($url) {
   try {
-    $response = drupal_http_request($url, $options);
-    if ($response->code == 200) {
-      return new SimpleXMLElement($response->data);
-    }
+    return new SimpleXMLElement($url, 0, true);
   } catch (Exception $e) {
     // swallow and fall through to the return false below
   }


### PR DESCRIPTION
Using drupal_http_request checks to see if the http request function has been overriden using the drupal_http_request_function variable, which in our case it has as we use httprl_override_core. There seems to be some issue in httprl though as the BHL requests fail - more specifically the first one succeeds (the NameSearch) and then any subsequent NameGetDetail requests fail with no error and a result code of 0. It's unclear why this happens and to avoid changing httprl from being used everywhere we'll just switch this over to use SimpleXMLElement's url fetching capabilities.