### PR TITLE
Patch HTTPRL lib and use it for BHL requests

### DIFF
--- a/sites/all/modules/contrib/httprl/httprl.module
+++ b/sites/all/modules/contrib/httprl/httprl.module
@@ -450,6 +450,7 @@ function httprl_set_default_options(&$options) {
     'chunk_size_write' => 1024,
     'async_connect' => TRUE,
     'ping_db' => 20,
+    'ignore_empty_chunk' => FALSE,
   );
 
   // Adjust Time To First Byte Timeout if timeout is large and ttfb is default.
@@ -1032,6 +1033,10 @@ function httprl_establish_stream_connection(&$result) {
  *   - ping_db: After X amount of time, ping the DB with a simple query in order
  *     to keep the connection alive. Default is every 20 seconds. Set to 0 to
  *     disable.
+ *   - ignore_empty_chunk: an empty chunk returned from a stream will:
+ *     default FALSE - make the connection not 'alive' and stop reading;
+ *     TRUE - not stop a stream from being 'alive' and will continue to read
+ *     until EOF or timeout.
  *
  * @return array
  *   Array where key is the URL and the value is the return value from
@@ -1502,7 +1507,12 @@ function httprl_send_request($results = NULL) {
 
           // Get stream data.
           $info = stream_get_meta_data($r);
-          $alive = !$info['eof'] && !feof($r) && !$info['timed_out'] && strlen($chunk);
+          $alive = !$info['eof'] && !feof($r) && !$info['timed_out'];
+          // Determine if an empty chunk of data means the connection should
+          // stop reading even though EOF or timeout has not occurred.
+          if ($alive && !$responses[$id]->options['ignore_empty_chunk'] && !strlen($chunk)) {
+            $alive = FALSE;
+          }
           if (!$alive) {
             if ($responses[$id]->status == 'Connecting.') {
               $responses[$id]->error = $t('Connection refused by destination. TCP.');

--- a/sites/all/modules/custom/scratchpads/scratchpads_species/modules/bhl/bhl.module
+++ b/sites/all/modules/custom/scratchpads/scratchpads_species/modules/bhl/bhl.module
@@ -194,18 +194,23 @@ function bhl_contextual_links_view_alter(&$element, $items){
 }
 
 /**
- * Fetches XML from the given URL with the given options. Uses the SimpleXMLElement constructor
- * function's ability to take a url and fetch the xml from it to get the data from the URL. If there
- * are any problems with the request (xml error etc) then this will return false, otherwise returns
- * the SimpleXMLElement object.
+ * Fetches XML from the given URL with the given options. Uses the drupal_http_request function to
+ * get the data from the URL. If there are any problems with the request (!200, xml error etc) then
+ * this will return false, otherwise returns the SimpleXMLElement object.
  *
  * @param string $url the url to request
  * @return bool|SimpleXMLElement false if there was a problem with getting the data from the URL, or
  *                               the SimpleXMLElement object if everything was fine
+ * @param array $options options for the request, default contains timeout: 30 and
+ *                       ignore_empty_chunk: true, the latter of which seems to be required for the
+ *                       httprl library to function with the BHL API.
  */
-function _bhl_fetch_xml($url) {
+function _bhl_fetch_xml($url, $options = array('timeout' => 30, 'ignore_empty_chunk' => true)) {
   try {
-    return new SimpleXMLElement($url, 0, true);
+    $response = drupal_http_request($url, $options);
+    if ($response->code == 200) {
+      return new SimpleXMLElement($response->data);
+    }
   } catch (Exception $e) {
     // swallow and fall through to the return false below
   }

--- a/sites/all/modules/patches/httprl-empty_chunk_continue-2818613-2-D7.patch
+++ b/sites/all/modules/patches/httprl-empty_chunk_continue-2818613-2-D7.patch
@@ -1,0 +1,37 @@
+diff --git a/sites/all/modules/contrib/httprl/httprl.module b/sites/all/modules/contrib/httprl/httprl.module
+index 78bd90a01..ff68cff87 100644
+--- a/sites/all/modules/contrib/httprl/httprl.module
++++ b/sites/all/modules/contrib/httprl/httprl.module
+@@ -450,6 +450,7 @@ function httprl_set_default_options(&$options) {
+     'chunk_size_write' => 1024,
+     'async_connect' => TRUE,
+     'ping_db' => 20,
++    'ignore_empty_chunk' => FALSE,
+   );
+ 
+   // Adjust Time To First Byte Timeout if timeout is large and ttfb is default.
+@@ -1032,6 +1033,10 @@ function httprl_establish_stream_connection(&$result) {
+  *   - ping_db: After X amount of time, ping the DB with a simple query in order
+  *     to keep the connection alive. Default is every 20 seconds. Set to 0 to
+  *     disable.
++ *   - ignore_empty_chunk: an empty chunk returned from a stream will:
++ *     default FALSE - make the connection not 'alive' and stop reading;
++ *     TRUE - not stop a stream from being 'alive' and will continue to read
++ *     until EOF or timeout.
+  *
+  * @return array
+  *   Array where key is the URL and the value is the return value from
+@@ -1502,7 +1507,12 @@ function httprl_send_request($results = NULL) {
+ 
+           // Get stream data.
+           $info = stream_get_meta_data($r);
+-          $alive = !$info['eof'] && !feof($r) && !$info['timed_out'] && strlen($chunk);
++          $alive = !$info['eof'] && !feof($r) && !$info['timed_out'];
++          // Determine if an empty chunk of data means the connection should
++          // stop reading even though EOF or timeout has not occurred.
++          if ($alive && !$responses[$id]->options['ignore_empty_chunk'] && !strlen($chunk)) {
++            $alive = FALSE;
++          }
+           if (!$alive) {
+             if ($responses[$id]->status == 'Connecting.') {
+               $responses[$id]->error = $t('Connection refused by destination. TCP.');


### PR DESCRIPTION
This PR contains a patch for the httprl library allowing it to accept empty chunks whilst reading from a URL. The code changes are identical to the ones presented as a patch on this issue: https://www.drupal.org/project/httprl/issues/2818613. The patch is written to maintain current functionality and is only enabled when an option is passed explicitly turning it on - this is what is done in the BHL related commit.

See commit messages for more details.
