### PR TITLE
Fix literature header being stretched to cover BHL block

### DIFF
--- a/sites/all/themes/scratchpads/css/global.css
+++ b/sites/all/themes/scratchpads/css/global.css
@@ -544,10 +544,6 @@ h1.site-name,h2.site-name {
   float:none!important;
 }
 
-.block-species-biblio-block,.block-species-spm-block {
-  float: none !important;
-}
-
 /* Embeded images */
 #zone-content div.content div.field-type-text-with-summary img,
 #zone-content div.content div.field-type-text img {


### PR DESCRIPTION
This reverts commit e982c78aee3372905c34ace4bee17fb4986c5548.

Fix for #5967

Ginger's work on #5892 should hopefully make Simon's commit unnecessary 