### PR TITLE
Add UTF8 locale support for non-debian

### DIFF
--- a/sites/all/modules/custom/scratchpads/scratchpads_tweaks/scratchpads_tweaks.module
+++ b/sites/all/modules/custom/scratchpads/scratchpads_tweaks/scratchpads_tweaks.module
@@ -8,7 +8,10 @@ define('SCRATCHPADS_VERSION', 'TAG');
  * Implements hook_init()
  */
 function scratchpads_tweaks_init(){
-  setlocale(LC_ALL, 'C.UTF-8');
+  // Try to set the locale to UTF8;
+  // C.UTF-8 is not available on Centos yet so include a fallback option
+  setlocale(LC_ALL, 'C.UTF-8', 'en_GB.UTF-8');
+
   if($_GET['q'] == 'admin/appearance/settings/scratchpads' || $_GET['q'] == 'admin/appearance/settings/scratchpads_em'){
     // Check to see if we're trying to view the
     // admin/appearance/settings/scratchpads


### PR DESCRIPTION
For #5972 - C.UTF-8 locale is not available for Centos so I'm just using en_GB.UTF-8 as a fallback.