### PR TITLE
Only filter lexicon terms via _lexicon_get_terms if already processing

### DIFF
--- a/sites/all/modules/contrib/lexicon/lexicon.module
+++ b/sites/all/modules/contrib/lexicon/lexicon.module
@@ -1087,6 +1087,9 @@ function _lexicon_get_terms(&$vids, $langcode = LANGUAGE_NONE) {
 
       // Add extra information to each term in the tree.
       foreach ($tree as $term) {
+        if (!$term->processing){
+          continue;
+        }
         _lexicon_term_add_info($term, TRUE);
         $terms[$langcode][] = $term;
       }
@@ -1108,6 +1111,7 @@ function _lexicon_term_add_info(&$term, $filter = FALSE) {
   // Check if the info has already been set.
   if (!isset($term->info_added)) {
     global $base_url;
+    $term->processing = true;
 
     $destination = drupal_get_destination();
 
@@ -1222,6 +1226,7 @@ function _lexicon_term_add_info(&$term, $filter = FALSE) {
     }
 
     $term->info_added = TRUE;
+    $term->processing = false;
   }
 
   return $term;


### PR DESCRIPTION
Not sure if this breaks something else, but if it does I haven't found it yet. Fixes #5997.

Avoids this situation, which prevents subsequent [bib][/bib] tags from being processed:

```
_lexicon_overview: for each term ->
    _lexicon_term_add_info(filter=false) ->
        *check_markup [calls bib tag processing] ->
            _filter_lexicon_process ->
                _lexicon_get_terms: for each term ->
                    _lexicon_term_add_info(filter=true) [prevents further processing of term]
```