### PR TITLE
Ignore empty strings in URL column on import

### DIFF
--- a/sites/all/modules/contrib/media_feeds/media_feeds.module
+++ b/sites/all/modules/contrib/media_feeds/media_feeds.module
@@ -77,6 +77,13 @@ function media_feeds_set_target($source, $entity, $target, $values, $config = ar
 
   foreach ($values as $value) {
     try {
+      // if the MediaFeedsInternetProvider is in use and the value is the empty string, then we
+      // ignore the value as the MediaFeedsInternetProvider will throw a
+      // MediaInternetNoHandlerException exception otherwise
+      if ($provider === 'MediaFeedsInternetProvider' && $value === '') {
+        continue;
+      }
+
       // Find a provider to create a file object.
       $provider = new $provider($value, $config);
 

--- a/sites/all/modules/patches/media_feeds_ignore_empty_values.patch
+++ b/sites/all/modules/patches/media_feeds_ignore_empty_values.patch
@@ -1,0 +1,18 @@
+diff --git a/sites/all/modules/contrib/media_feeds/media_feeds.module b/sites/all/modules/contrib/media_feeds/media_feeds.module
+index 8496d9691..1d7926a58 100644
+--- a/sites/all/modules/contrib/media_feeds/media_feeds.module
++++ b/sites/all/modules/contrib/media_feeds/media_feeds.module
+@@ -77,6 +77,13 @@ function media_feeds_set_target($source, $entity, $target, $values, $config = ar
+ 
+   foreach ($values as $value) {
+     try {
++      // if the MediaFeedsInternetProvider is in use and the value is the empty string, then we
++      // ignore the value as the MediaFeedsInternetProvider will throw a
++      // MediaInternetNoHandlerException exception otherwise
++      if ($provider === 'MediaFeedsInternetProvider' && $value === '') {
++        continue;
++      }
++
+       // Find a provider to create a file object.
+       $provider = new $provider($value, $config);
+ 


### PR DESCRIPTION
If the url is an empty string then the `MediaFeedsInternetProvider` will throw a `MediaInternetNoHandlerException` because it can't find a handler for it. Presumably, this is desired under normal circumstances, but during an import the cell's values are empty strings so this error is thrown all the time. Therefore, preempt it before it happens!

I fixed it like this rather than patching the `MediaFeedsInternetProvider` itself under the assumption that other code is expecting it to throw `MediaInternetNoHandlerException` exceptions when it encounters
invalid strings, like the empty string. Does feel a bit hacky though.

https://github.com/NaturalHistoryMuseum/scratchpads2/issues/6062