### PR TITLE
Fix pubmed imports

### DIFF
--- a/sites/all/modules/contrib/biblio/modules/pubmed/EntrezClient.php
+++ b/sites/all/modules/contrib/biblio/modules/pubmed/EntrezClient.php
@@ -9,7 +9,7 @@ class BiblioEntrezClient
 {
   const DEFAULT_DATABASE = 'pubmed';
 
-  const BASE_URL = 'http://eutils.ncbi.nlm.nih.gov/entrez/eutils/';
+  const BASE_URL = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/';
 
   private $database = self::DEFAULT_DATABASE;
 

--- a/sites/all/modules/contrib/biblio/modules/pubmed/biblio_pm.module
+++ b/sites/all/modules/contrib/biblio/modules/pubmed/biblio_pm.module
@@ -114,7 +114,7 @@ function biblio_pm_form_biblio_node_form_alter(&$form, &$form_state, $form_id) {
       );
 
   }
-  if ((!isset($form_state['biblio_type']) || empty($form_state['biblio_type'])) && !isset($form_state['node']->nid)) {
+  if (!$form_state['submitted'] && !isset($form['#node']->nid)) {
     $form['biblio_pubmed_lookup'] = array(
         '#type' => 'fieldset',
         '#title' => t('PubMed Lookup'),

--- a/sites/all/modules/patches/update_the_pubmed_form_check_to_work.patch
+++ b/sites/all/modules/patches/update_the_pubmed_form_check_to_work.patch
@@ -1,0 +1,13 @@
+diff --git a/sites/all/modules/contrib/biblio/modules/pubmed/biblio_pm.module b/sites/all/modules/contrib/biblio/modules/pubmed/biblio_pm.module
+index adf237f92..100669ad2 100644
+--- a/sites/all/modules/contrib/biblio/modules/pubmed/biblio_pm.module
++++ b/sites/all/modules/contrib/biblio/modules/pubmed/biblio_pm.module
+@@ -114,7 +114,7 @@ function biblio_pm_form_biblio_node_form_alter(&$form, &$form_state, $form_id) {
+       );
+ 
+   }
+-  if ((!isset($form_state['biblio_type']) || empty($form_state['biblio_type'])) && !isset($form_state['node']->nid)) {
++  if (!$form_state['submitted'] && !isset($form['#node']->nid)) {
+     $form['biblio_pubmed_lookup'] = array(
+         '#type' => 'fieldset',
+         '#title' => t('PubMed Lookup'),

--- a/sites/all/modules/patches/use_https_for_pubmed_api.patch
+++ b/sites/all/modules/patches/use_https_for_pubmed_api.patch
@@ -1,0 +1,13 @@
+diff --git a/sites/all/modules/contrib/biblio/modules/pubmed/EntrezClient.php b/sites/all/modules/contrib/biblio/modules/pubmed/EntrezClient.php
+index 9c88a9244..0f4dd6f36 100644
+--- a/sites/all/modules/contrib/biblio/modules/pubmed/EntrezClient.php
++++ b/sites/all/modules/contrib/biblio/modules/pubmed/EntrezClient.php
+@@ -9,7 +9,7 @@ class BiblioEntrezClient
+ {
+   const DEFAULT_DATABASE = 'pubmed';
+ 
+-  const BASE_URL = 'http://eutils.ncbi.nlm.nih.gov/entrez/eutils/';
++  const BASE_URL = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/';
+ 
+   private $database = self::DEFAULT_DATABASE;
+ 


### PR DESCRIPTION
Two parts to this:

1. The pubmed API has to be accessed over https now otherwise you get a 403.
2. The form wasn't showing due to a change made ages ago (see https://github.com/NaturalHistoryMuseum/scratchpads2/commit/45e68c01fd213a3c0004921c2b2e273726043590 commit message)

Fixes https://github.com/NaturalHistoryMuseum/scratchpads2/issues/6047