### PR TITLE
Allow DOIs to be imported using the URL as well as the short form

### DIFF
--- a/sites/all/modules/contrib/biblio/modules/crossref/biblio_crossref.module
+++ b/sites/all/modules/contrib/biblio/modules/crossref/biblio_crossref.module
@@ -32,7 +32,7 @@ function biblio_crossref_form_biblio_node_form_alter(&$form, &$form_state) {
         '#title' => t('DOI'),
         '#required' => FALSE,
         '#default_value' => (isset($form_state['values']['doi_data']) ? $form_state['values']['doi_data'] : ''),
-        '#description' => t('Enter a DOI name in the form: <b>10.1000/123456</b>'),
+        '#description' => t('Enter a DOI in the form: <b>10.1000/123456</b> or the full URL: <b>https://doi.org/10.1000/123456</b>'),
         '#disabled' => empty($have_pid),
         '#size' => 60,
         '#maxlength' => 255,
@@ -54,8 +54,11 @@ function biblio_crossref_form_biblio_node_form_alter(&$form, &$form_state) {
 function biblio_crossref_form_biblio_node_form_submit($form, &$form_state) {
   global $user;
   $node_data = array();
-  if (strlen($doi = $form_state['values']['doi_data'])) {
-    if (($doi_start = strpos($form_state['values']['doi_data'], '10.')) !== FALSE) {
+  if (strlen($form_state['values']['doi_data'])) {
+    // this regex matches "modern" crossref patterns, see here: https://www.crossref.org/blog/dois-and-matching-regular-expressions/
+    preg_match('/^.*?(10.\d{4,9}\/[-._;()\/:a-zA-Z0-9]+)$/i', $form_state['values']['doi_data'], $match);
+    if ($match) {
+      $doi = $match[1];
       if (!($dup = biblio_crossref_check_doi($doi))) {
         $crossref_pid = variable_get('biblio_crossref_pid', '');
         $user_pid = (isset($user->data['biblio_crossref_pid']) && !empty($user->data['biblio_crossref_pid'])) ? $user->data['biblio_crossref_pid'] : '';
@@ -86,7 +89,7 @@ function biblio_crossref_form_biblio_node_form_submit($form, &$form_state) {
       }
     }
     else {
-      form_set_error('doi_data', t('This does not appear to be a valid DOI name, it should start with "10."'));
+      form_set_error('doi_data', t('This does not appear to be a valid DOI name'));
     }
   }
   $form_state['rebuild'] = TRUE;

--- a/sites/all/modules/patches/allow_full_doi_urls.patch
+++ b/sites/all/modules/patches/allow_full_doi_urls.patch
@@ -1,0 +1,36 @@
+diff --git a/sites/all/modules/contrib/biblio/modules/crossref/biblio_crossref.module b/sites/all/modules/contrib/biblio/modules/crossref/biblio_crossref.module
+index 36920e231..0a2e61827 100644
+--- a/sites/all/modules/contrib/biblio/modules/crossref/biblio_crossref.module
++++ b/sites/all/modules/contrib/biblio/modules/crossref/biblio_crossref.module
+@@ -32,7 +32,7 @@ function biblio_crossref_form_biblio_node_form_alter(&$form, &$form_state) {
+         '#title' => t('DOI'),
+         '#required' => FALSE,
+         '#default_value' => (isset($form_state['values']['doi_data']) ? $form_state['values']['doi_data'] : ''),
+-        '#description' => t('Enter a DOI name in the form: <b>10.1000/123456</b>'),
++        '#description' => t('Enter a DOI in the form: <b>10.1000/123456</b> or the full URL: <b>https://doi.org/10.1000/123456</b>'),
+         '#disabled' => empty($have_pid),
+         '#size' => 60,
+         '#maxlength' => 255,
+@@ -54,8 +54,11 @@ function biblio_crossref_form_biblio_node_form_alter(&$form, &$form_state) {
+ function biblio_crossref_form_biblio_node_form_submit($form, &$form_state) {
+   global $user;
+   $node_data = array();
+-  if (strlen($doi = $form_state['values']['doi_data'])) {
+-    if (($doi_start = strpos($form_state['values']['doi_data'], '10.')) !== FALSE) {
++  if (strlen($form_state['values']['doi_data'])) {
++    // this regex matches "modern" crossref patterns, see here: https://www.crossref.org/blog/dois-and-matching-regular-expressions/
++    preg_match('/^.*?(10.\d{4,9}\/[-._;()\/:a-zA-Z0-9]+)$/i', $form_state['values']['doi_data'], $match);
++    if ($match) {
++      $doi = $match[1];
+       if (!($dup = biblio_crossref_check_doi($doi))) {
+         $crossref_pid = variable_get('biblio_crossref_pid', '');
+         $user_pid = (isset($user->data['biblio_crossref_pid']) && !empty($user->data['biblio_crossref_pid'])) ? $user->data['biblio_crossref_pid'] : '';
+@@ -86,7 +89,7 @@ function biblio_crossref_form_biblio_node_form_submit($form, &$form_state) {
+       }
+     }
+     else {
+-      form_set_error('doi_data', t('This does not appear to be a valid DOI name, it should start with "10."'));
++      form_set_error('doi_data', t('This does not appear to be a valid DOI name'));
+     }
+   }
+   $form_state['rebuild'] = TRUE;


### PR DESCRIPTION
This is done using a regex to ensure we cover off:

- 10.1000/123456
- https://doi.org/10.1000/123456
- https://dx.doi.org/10.1000/123456

etc.

The regex just matches .*10.etc.

Fixes https://github.com/NaturalHistoryMuseum/scratchpads2/issues/5717