### PR TITLE
Add an import operation to the taxonomy admin view

### DIFF
--- a/modules/taxonomy/taxonomy.admin.inc
+++ b/modules/taxonomy/taxonomy.admin.inc
@@ -25,6 +25,7 @@ function taxonomy_overview_vocabularies($form) {
       '#delta' => 10,
       '#default_value' => $vocabulary->weight,
     );
+    $form[$vocabulary->vid]['#opkeys'] = ['edit', 'list', 'add'];
     $form[$vocabulary->vid]['edit'] = array('#type' => 'link', '#title' => t('edit vocabulary'), '#href' => "admin/structure/taxonomy/$vocabulary->machine_name/edit");
     $form[$vocabulary->vid]['list'] = array('#type' => 'link', '#title' => t('list terms'), '#href' => "admin/structure/taxonomy/$vocabulary->machine_name");
     $form[$vocabulary->vid]['add'] = array('#type' => 'link', '#title' => t('add terms'), '#href' => "admin/structure/taxonomy/$vocabulary->machine_name/add");
@@ -69,8 +70,9 @@ function taxonomy_overview_vocabularies_submit($form, &$form_state) {
  */
 function theme_taxonomy_overview_vocabularies($variables) {
   $form = $variables['form'];
-
   $rows = array();
+  # use this array to track how many operation columns we're showing
+  $operations = array();
 
   foreach (element_children($form) as $key) {
     if (isset($form[$key]['name'])) {
@@ -82,9 +84,11 @@ function theme_taxonomy_overview_vocabularies($variables) {
         $vocabulary['weight']['#attributes']['class'] = array('vocabulary-weight');
         $row[] = drupal_render($vocabulary['weight']);
       }
-      $row[] = drupal_render($vocabulary['edit']);
-      $row[] = drupal_render($vocabulary['list']);
-      $row[] = drupal_render($vocabulary['add']);
+      foreach ($vocabulary['#opkeys'] as $opkey) {
+        $row[] = drupal_render($vocabulary[$opkey]);
+        # add the key to the array
+        $operations[$opkey] = TRUE;
+      }
       $rows[] = array('data' => $row, 'class' => array('draggable'));
     }
   }
@@ -94,7 +98,7 @@ function theme_taxonomy_overview_vocabularies($variables) {
     $header[] = t('Weight');
     drupal_add_tabledrag('taxonomy', 'order', 'sibling', 'vocabulary-weight');
   }
-  $header[] = array('data' => t('Operations'), 'colspan' => '3');
+  $header[] = array('data' => t('Operations'), 'colspan' => count($operations));
   return theme('table', array('header' => $header, 'rows' => $rows, 'empty' => t('No vocabularies available. <a href="@link">Add vocabulary</a>.', array('@link' => url('admin/structure/taxonomy/add'))), 'attributes' => array('id' => 'taxonomy'))) . drupal_render_children($form);
 }
 

--- a/patches/taxonomy_admin_view_allow_custom_operations.patch
+++ b/patches/taxonomy_admin_view_allow_custom_operations.patch
@@ -1,0 +1,47 @@
+diff --git a/modules/taxonomy/taxonomy.admin.inc b/modules/taxonomy/taxonomy.admin.inc
+index 828fde0ab..67aaa17a9 100644
+--- a/modules/taxonomy/taxonomy.admin.inc
++++ b/modules/taxonomy/taxonomy.admin.inc
+@@ -25,6 +25,7 @@ function taxonomy_overview_vocabularies($form) {
+       '#delta' => 10,
+       '#default_value' => $vocabulary->weight,
+     );
++    $form[$vocabulary->vid]['#opkeys'] = ['edit', 'list', 'add'];
+     $form[$vocabulary->vid]['edit'] = array('#type' => 'link', '#title' => t('edit vocabulary'), '#href' => "admin/structure/taxonomy/$vocabulary->machine_name/edit");
+     $form[$vocabulary->vid]['list'] = array('#type' => 'link', '#title' => t('list terms'), '#href' => "admin/structure/taxonomy/$vocabulary->machine_name");
+     $form[$vocabulary->vid]['add'] = array('#type' => 'link', '#title' => t('add terms'), '#href' => "admin/structure/taxonomy/$vocabulary->machine_name/add");
+@@ -69,8 +70,9 @@ function taxonomy_overview_vocabularies_submit($form, &$form_state) {
+  */
+ function theme_taxonomy_overview_vocabularies($variables) {
+   $form = $variables['form'];
+-
+   $rows = array();
++  # use this array to track how many operation columns we're showing
++  $operations = array();
+ 
+   foreach (element_children($form) as $key) {
+     if (isset($form[$key]['name'])) {
+@@ -82,9 +84,11 @@ function theme_taxonomy_overview_vocabularies($variables) {
+         $vocabulary['weight']['#attributes']['class'] = array('vocabulary-weight');
+         $row[] = drupal_render($vocabulary['weight']);
+       }
+-      $row[] = drupal_render($vocabulary['edit']);
+-      $row[] = drupal_render($vocabulary['list']);
+-      $row[] = drupal_render($vocabulary['add']);
++      foreach ($vocabulary['#opkeys'] as $opkey) {
++        $row[] = drupal_render($vocabulary[$opkey]);
++        # add the key to the array
++        $operations[$opkey] = TRUE;
++      }
+       $rows[] = array('data' => $row, 'class' => array('draggable'));
+     }
+   }
+@@ -94,7 +98,7 @@ function theme_taxonomy_overview_vocabularies($variables) {
+     $header[] = t('Weight');
+     drupal_add_tabledrag('taxonomy', 'order', 'sibling', 'vocabulary-weight');
+   }
+-  $header[] = array('data' => t('Operations'), 'colspan' => '3');
++  $header[] = array('data' => t('Operations'), 'colspan' => count($operations));
+   return theme('table', array('header' => $header, 'rows' => $rows, 'empty' => t('No vocabularies available. <a href="@link">Add vocabulary</a>.', array('@link' => url('admin/structure/taxonomy/add'))), 'attributes' => array('id' => 'taxonomy'))) . drupal_render_children($form);
+ }
+ 

--- a/sites/all/modules/custom/scratchpads/scratchpads_tweaks/scratchpads_tweaks.module
+++ b/sites/all/modules/custom/scratchpads/scratchpads_tweaks/scratchpads_tweaks.module
@@ -849,3 +849,29 @@ function scratchpads_tweaks_views_post_build(&$view) {
     $view->build_info['title'] = $view->title;
   }
 }
+
+
+/**
+ * Implementation of hook_form_FORM_ID_alter().
+ *
+ * This adds an import link to each vocabulary on the taxaonomy admin view allowing users to navigate directly from the
+ * admin view to the taxonomy import page for the given vocabulary.
+ */
+function scratchpads_tweaks_form_taxonomy_overview_vocabularies_alter(&$form, &$form_state) {
+  foreach (element_children($form) as $key) {
+    # get a reference to the child we're going to work on
+    $child = &$form[$key];
+    # the key will be the vocabulary id if the child is a vocabulary so check that as well as whether the other keys
+    # we require exist
+    if (is_numeric($key) && array_key_exists('#vocabulary', $child) && array_key_exists('#opkeys', $child)) {
+      $child['import'] = array(
+        '#type' => 'link',
+        '#title' => t('Import'),
+        # link to xls importer by default to match other import admin view shortcut links (might be because the xls feed
+        # importer is always available whereas the csv one is optional?)
+        '#href' => 'import/taxonomy_importer_' . $child['#vocabulary']->machine_name . '_xls'
+      );
+      $child['#opkeys'][] = 'import';
+    }
+  }
+}


### PR DESCRIPTION
Add an `Import` operation to the taxonomy admin view. Because of the way the form is built, I had to patch the taxonomy module to accept other operations beyond `add`, `edit` and `list` which are all hard-coded into the module (argh). It would be great to get some input from both/either @PaulKiddle / @benscott on this one before merging in case there's a better way to achieve this.

Fixes: https://github.com/NaturalHistoryMuseum/scratchpads2/issues/5881