### PR TITLE
Use unshift instead of push when adding the fids to the form values array

### DIFF
--- a/sites/all/modules/contrib/media_multiselect/media_multiselect.js
+++ b/sites/all/modules/contrib/media_multiselect/media_multiselect.js
@@ -16,7 +16,7 @@
               
               // Add the fids to the form_values.
               for (var i=0; i<this.media_multiselect_files.length; i++) {
-                form_values.push({name: 'media_multiselect_fids[]', value: this.media_multiselect_files[i].fid});
+                form_values.unshift({name: 'media_multiselect_fids[]', value: this.media_multiselect_files[i].fid});
               }
 
               // Call the prototype, so we preseve any existing functionality in there.

--- a/sites/all/modules/patches/media_multiselect_unshift.patch
+++ b/sites/all/modules/patches/media_multiselect_unshift.patch
@@ -1,0 +1,13 @@
+diff --git a/sites/all/modules/contrib/media_multiselect/media_multiselect.js b/sites/all/modules/contrib/media_multiselect/media_multiselect.js
+index 26bce8a67..fded67116 100644
+--- a/sites/all/modules/contrib/media_multiselect/media_multiselect.js
++++ b/sites/all/modules/contrib/media_multiselect/media_multiselect.js
+@@ -16,7 +16,7 @@
+               
+               // Add the fids to the form_values.
+               for (var i=0; i<this.media_multiselect_files.length; i++) {
+-                form_values.push({name: 'media_multiselect_fids[]', value: this.media_multiselect_files[i].fid});
++                form_values.unshift({name: 'media_multiselect_fids[]', value: this.media_multiselect_files[i].fid});
+               }
+ 
+               // Call the prototype, so we preseve any existing functionality in there.


### PR DESCRIPTION
I'm not 100% clear why this works, but when using push the values do not come through in the php. My guess would be that adding the values to the end of the form values array places them after some value that the php code recognises as the end of the form values and the start of other stuff that it can ignore. For example, the form values I've been working with on a biblio node has over a 1000 elements, the first few are the form values and then the other like 990 are "ajax_html_ids[]" and "ajax_page_state" items. Any way, adding the values to the start of list means they come through in the php and it all works.

Fixes https://github.com/NaturalHistoryMuseum/scratchpads2/issues/5723