### PR TITLE
Use htmlspecialchars to make title xml safe

### DIFF
--- a/sites/all/modules/custom/scratchpads/scratchpads_biblio/scratchpads_biblio.module
+++ b/sites/all/modules/custom/scratchpads/scratchpads_biblio/scratchpads_biblio.module
@@ -23,7 +23,7 @@ function scratchpads_biblio_form_node_form_validate(&$form, &$form_state)
   $title = $form_state['values']['title'];
   if (strpos($title, '<') !== false) {
     libxml_use_internal_errors(true);
-    $xmlString = '<xml>' . str_replace('&', '&amp;', $title) . '</xml>';
+    $xmlString = '<xml>' . htmlspecialchars($title) . '</xml>';
     $doc = simplexml_load_string($xmlString);
     $errors = libxml_get_errors();
     if (!$doc || $errors) {


### PR DESCRIPTION
I think #5982 was already fixed but this might help in future (or it'll create more problems, I don't know)