### PR TITLE
Decode html chars when displaying node titles on taxon pages

### DIFF
--- a/sites/all/modules/custom/scratchpads/scratchpads_simple_taxonomy_page/scratchpads_simple_taxonomy_page.module
+++ b/sites/all/modules/custom/scratchpads/scratchpads_simple_taxonomy_page/scratchpads_simple_taxonomy_page.module
@@ -505,4 +505,7 @@ function scratchpads_simple_taxonomy_page_preprocess_node(&$variables){
     // Keeping the title as a single space ensures the edit links are displayed
     $variables['title'] = ' ';
   }
+  if(isset($variables['title'])){
+    $variables['title'] = htmlspecialchars_decode($variables['title']);
+  }
 }


### PR DESCRIPTION
Fixes #6037 
Bonus: also handles `<` and `>` so html tags are also fine now.