### PR TITLE
Return an error when autocompleting taxons without a vocabulary

### DIFF
--- a/sites/all/modules/custom/scratchpads/scratchpads_taxonomic_name_field/scratchpads_taxonomic_name_field.module
+++ b/sites/all/modules/custom/scratchpads/scratchpads_taxonomic_name_field/scratchpads_taxonomic_name_field.module
@@ -254,6 +254,11 @@ function scratchpads_taxonomic_name_field_autocomplete($field_name, $tags_typed 
     ));
     exit();
   }
+  // we need at least one vocabulary associated with the field to filter the results. If there aren't any, error
+  if (empty($field['settings']['allowed_values'])) {
+    print t('Taxonomy field @field_name must have at least one associated vocabulary.', ['@field_name' => $field_name]);
+    exit();
+  }
   // The user enters a comma-separated list of tags. We only autocomplete the
   // last tag.
   $tags_typed = drupal_explode_tags($tags_typed);


### PR DESCRIPTION
Closes: https://github.com/NaturalHistoryMuseum/scratchpads2/issues/5866

Firstly, just for completeness, the reason this was breaking was because we were attempting to run an empty `in` clause. The difference between the two queries is that the second has values in it's in clause:

![image](https://user-images.githubusercontent.com/4718259/72907844-835d3300-3d2c-11ea-9660-552020e90a45.png)

What those values are and where they come from I'm not sure of though, I'm also not sure why both autocomplete paths were being used at different times on the same page.

Either way, the fundamental issue is in the `scratchpads_taxonomic_name_field_autocomplete` function. So what do we do if there aren't any vocabularies set on the field? There are 3 choices as far as I can see:

1. Return an empty array as we know that nothing should match the query.
2. Miss out the `in` clause and search all taxonomies.
3. Return an error.

I chose to go with the 3rd choice but I'm happy to debate this. I definitely don't think we should do option 2, but option 1 is a possibility.

Input from @alycejenni, @PaulKiddle and @benscott welcome!