### PR TITLE
Add 'alpha' class to ecoint block to match other blocks

### DIFF
--- a/sites/all/modules/custom/ecoint/ecoint.module
+++ b/sites/all/modules/custom/ecoint/ecoint.module
@@ -148,6 +148,7 @@ function ecoint_block_view($delta = ''){
 function ecoint_preprocess_block(&$variables){
   if($variables['block']->module == 'ecoint' && $variables['block']->delta == 'species-interactions'){
     $variables['classes_array'][] = drupal_html_class('grid-8');
+    $variables['classes_array'][] = drupal_html_class('alpha');
   }
 }
 


### PR DESCRIPTION
Without `alpha` or `omega` class, has 10px left-right margins.
Fixes #6042