### PR TITLE
Revert "Remove duplicates from species media view"

### DIFF
--- a/sites/all/modules/custom/scratchpads/scratchpads_species/views/scratchpads_species.views_default.inc
+++ b/sites/all/modules/custom/scratchpads/scratchpads_species/views/scratchpads_species.views_default.inc
@@ -2084,9 +2084,6 @@ function scratchpads_species_views_default_views(){
     $handler = $view->new_display('block', 'Block', 'block');
     $handler->display->display_options['defaults']['css_class'] = FALSE;
     $handler->display->display_options['css_class'] = 'view-inline-filters grid-8 alpha omega';
-    $handler->display->display_options['defaults']['query'] = FALSE;
-    $handler->display->display_options['query']['type'] = 'views_query';
-    $handler->display->display_options['query']['options']['distinct'] = TRUE;
     /* Display: Count images */
     $handler = $view->new_display('attachment', 'Count images', 'attachment_1');
     $handler->display->display_options['defaults']['group_by'] = FALSE;
@@ -2107,7 +2104,7 @@ function scratchpads_species_views_default_views(){
     $handler->display->display_options['fields']['fid']['id'] = 'fid';
     $handler->display->display_options['fields']['fid']['table'] = 'file_managed';
     $handler->display->display_options['fields']['fid']['field'] = 'fid';
-    $handler->display->display_options['fields']['fid']['group_type'] = 'count_distinct';
+    $handler->display->display_options['fields']['fid']['group_type'] = 'count';
     $handler->display->display_options['fields']['fid']['label'] = '';
     $handler->display->display_options['fields']['fid']['alter']['alter_text'] = 1;
     $handler->display->display_options['fields']['fid']['alter']['text'] = 'Images ([fid])';
@@ -2177,7 +2174,7 @@ function scratchpads_species_views_default_views(){
     $handler->display->display_options['fields']['fid']['id'] = 'fid';
     $handler->display->display_options['fields']['fid']['table'] = 'file_managed';
     $handler->display->display_options['fields']['fid']['field'] = 'fid';
-    $handler->display->display_options['fields']['fid']['group_type'] = 'count_distinct';
+    $handler->display->display_options['fields']['fid']['group_type'] = 'count';
     $handler->display->display_options['fields']['fid']['label'] = '';
     $handler->display->display_options['fields']['fid']['alter']['alter_text'] = 1;
     $handler->display->display_options['fields']['fid']['alter']['text'] = 'Videos ([fid])';
@@ -2247,7 +2244,7 @@ function scratchpads_species_views_default_views(){
     $handler->display->display_options['fields']['fid']['id'] = 'fid';
     $handler->display->display_options['fields']['fid']['table'] = 'file_managed';
     $handler->display->display_options['fields']['fid']['field'] = 'fid';
-    $handler->display->display_options['fields']['fid']['group_type'] = 'count_distinct';
+    $handler->display->display_options['fields']['fid']['group_type'] = 'count';
     $handler->display->display_options['fields']['fid']['label'] = '';
     $handler->display->display_options['fields']['fid']['alter']['alter_text'] = 1;
     $handler->display->display_options['fields']['fid']['alter']['text'] = 'Audio ([fid])';


### PR DESCRIPTION
Reverts NaturalHistoryMuseum/scratchpads2#6129

Reverting this because it seems to be the cause of an error during the release. Seeing as I've already manually made the change to the sites of the users that reported the issue it's easy enough to remove from 2.9.12 for now so that we can get everything else released while we figure out what the problem with this change is.

```
ERROR
FieldException: Attempt to create an instance of a field endpoints that doesn't exist or is currently inactive. in /var/aegir/platforms/scratchpads-2.9.11/modules/field/field.crud.inc:476             [error]
Stack trace:
#0 /var/aegir/platforms/scratchpads-2.9.11/sites/all/modules/contrib/relation/relation.module(303): field_create_instance(Array)
#1 /var/aegir/platforms/scratchpads-2.9.11/sites/all/modules/contrib/relation/relation.module(344): relation_type_ensure_instance('character')
#2 /var/aegir/platforms/scratchpads-2.9.11/sites/all/modules/contrib/relation/relation.module(97): relation_get_types()
#3 /var/aegir/platforms/scratchpads-2.9.11/includes/module.inc(1171): relation_entity_property_info_alter(Array, NULL, NULL, NULL)
#4 /var/aegir/platforms/scratchpads-2.9.11/sites/all/modules/contrib/entity/includes/entity.property.inc(39): drupal_alter('entity_property...', Array)
#5 /var/aegir/platforms/scratchpads-2.9.11/sites/all/modules/contrib/entity/views/entity.views.inc(445): entity_get_property_info('field_collectio...')
#6 /var/aegir/platforms/scratchpads-2.9.11/sites/all/modules/contrib/entity/views/entity.views.inc(387): EntityDefaultViewsController->schema_fields()
#7 /var/aegir/platforms/scratchpads-2.9.11/sites/all/modules/contrib/entity/views/entity.views.inc(33): EntityDefaultViewsController->views_data()
#8 /var/aegir/platforms/scratchpads-2.9.11/includes/module.inc(965): entity_views_data()
#9 /var/aegir/platforms/scratchpads-2.9.11/sites/all/modules/contrib/views/includes/cache.inc(92): module_invoke_all('views_data')
#10 /var/aegir/platforms/scratchpads-2.9.11/sites/all/modules/contrib/views/includes/cache.inc(77): _views_fetch_data_build()
#11 /var/aegir/platforms/scratchpads-2.9.11/sites/all/modules/contrib/views/views.module(1361): _views_fetch_data(NULL, true, false)
#12 /var/aegir/platforms/scratchpads-2.9.11/sites/all/modules/contrib/entity/views/entity.views.inc(320): views_fetch_data()
#13 /var/aegir/platforms/scratchpads-2.9.11/sites/all/modules/contrib/views/includes/plugins.inc(417): entity_views_plugins()
#14 /var/aegir/platforms/scratchpads-2.9.11/sites/all/modules/contrib/views/includes/cache.inc(148): views_discover_plugins()
#15 /var/aegir/platforms/scratchpads-2.9.11/sites/all/modules/contrib/views/views.module(1369): _views_fetch_plugin_data('display', 'default', false)
#16 /var/aegir/platforms/scratchpads-2.9.11/sites/all/modules/contrib/views/includes/view.inc(2382): views_fetch_plugin_data('display', 'default')
#17 /var/aegir/platforms/scratchpads-2.9.11/sites/all/modules/contrib/views/includes/view.inc(2479): views_db_object->add_display('default', 'Master', 'default')
#18 /var/aegir/platforms/scratchpads-2.9.11/sites/all/modules/custom/scratchpads/scratchpads_species/views/scratchpads_species.views_default.inc(20): views_db_object->new_display('default', 'Master',
'default')
#19 /var/aegir/platforms/scratchpads-2.9.11/includes/module.inc(965): scratchpads_species_views_default_views()
#20 /var/aegir/platforms/scratchpads-2.9.11/sites/all/modules/custom/scratchpads/scratchpads_species/scratchpads_species.module(990): module_invoke_all('views_default_v...')
#21 /var/aegir/platforms/scratchpads-2.9.11/sites/all/modules/custom/scratchpads/scratchpads_species/scratchpads_species.module(970): scratchpads_species_get_all_views()
#22 /var/aegir/platforms/scratchpads-2.9.11/sites/all/modules/custom/scratchpads/scratchpads_species/scratchpads_species.context.inc(67): scratchpads_species_get_context_views('species_overvie...')
#23 /var/aegir/platforms/scratchpads-2.9.11/sites/all/modules/contrib/ctools/includes/export.inc(679): scratchpads_species_context_default_contexts(Array)
#24 /var/aegir/platforms/scratchpads-2.9.11/sites/all/modules/contrib/ctools/includes/export.inc(496): _ctools_export_get_defaults('context', Array)
#25 /var/aegir/platforms/scratchpads-2.9.11/sites/all/modules/contrib/context/context.module(232): ctools_export_load_object('context', 'all')
#26 /var/aegir/platforms/scratchpads-2.9.11/sites/all/modules/contrib/context/context.module(358): context_load(NULL, false)
#27 /var/aegir/platforms/scratchpads-2.9.11/sites/all/modules/contrib/context/context.module(421): context_enabled_contexts()
#28 /var/aegir/platforms/scratchpads-2.9.11/sites/all/modules/contrib/context/plugins/context_condition.inc(160): context_condition_map()
#29 /var/aegir/platforms/scratchpads-2.9.11/sites/all/modules/contrib/context/plugins/context_condition_sitewide.inc(19): context_condition->get_contexts(1)
#30 /var/aegir/platforms/scratchpads-2.9.11/sites/all/modules/contrib/context/context.module(169): context_condition_sitewide->execute(1)
#31 /var/aegir/platforms/scratchpads-2.9.11/includes/module.inc(965): context_init()
#32 /var/aegir/platforms/scratchpads-2.9.11/includes/common.inc(5328): module_invoke_all('init')
#33 /var/aegir/platforms/scratchpads-2.9.11/includes/bootstrap.inc(2551): _drupal_bootstrap_full()
#34 phar:///var/aegir/.composer/global/drush/drush/vendor/drush/drush/drush/lib/Drush/Boot/DrupalBoot7.php(91): drupal_bootstrap(7)
#35 phar:///var/aegir/.composer/global/drush/drush/vendor/drush/drush/drush/includes/bootstrap.inc(354): Drush\Boot\DrupalBoot7->bootstrap_drupal_full()
#36 /var/aegir/.drush/provision/platform/verify.provision.inc(22): drush_bootstrap(5)
#37 phar:///var/aegir/.composer/global/drush/drush/vendor/drush/drush/drush/includes/command.inc(422): drush_provision_drupal_provision_verify_validate()
#38 phar:///var/aegir/.composer/global/drush/drush/vendor/drush/drush/drush/includes/command.inc(231): _drush_invoke_hooks(Array, Array)
#39 phar:///var/aegir/.composer/global/drush/drush/vendor/drush/drush/drush/includes/command.inc(199): drush_command()
#40 phar:///var/aegir/.composer/global/drush/drush/vendor/drush/drush/drush/lib/Drush/Boot/BaseBoot.php(67): drush_dispatch(Array)
#41 phar:///var/aegir/.composer/global/drush/drush/vendor/drush/drush/drush/includes/preflight.inc(67): Drush\Boot\BaseBoot->bootstrap_and_dispatch()
#42 phar:///var/aegir/.composer/global/drush/drush/vendor/drush/drush/drush/includes/startup.inc(465): drush_main()
#43 phar:///var/aegir/.composer/global/drush/drush/vendor/drush/drush/drush/includes/startup.inc(369): drush_run_main(false, '/', 'Phar detected. ...')
#44 phar:///var/aegir/.composer/global/drush/drush/vendor/drush/drush/drush/drush(114): drush_startup(Array)
#45 /var/aegir/.composer/global/drush/drush/vendor/drush/drush/drush(10): require('phar:///var/aeg...')
#46 {main}
```
