### PR TITLE
Allow multiple import columns to map to a single media field

### DIFF
--- a/sites/all/modules/contrib/media_feeds/media_feeds.module
+++ b/sites/all/modules/contrib/media_feeds/media_feeds.module
@@ -73,7 +73,12 @@ function media_feeds_set_target($source, $entity, $target, $values, $config = ar
   list($target, $provider) = explode(':', $target, 2) + array(1 => 'MediaFeedsInternetProvider');
 
   $field_info = field_info_field($target);
-  $field = array(LANGUAGE_NONE => array());
+  // ensure we don't overwrite any existing values from other columns in the import which are writing to the same field
+  if (property_exists($entity, $target)) {
+    $field = $entity->{$target};
+  } else {
+    $field = array(LANGUAGE_NONE => array());
+  }
 
   foreach ($values as $value) {
     try {

--- a/sites/all/modules/patches/media_feeds_allow_multiple_import_column_sources_per_field.patch
+++ b/sites/all/modules/patches/media_feeds_allow_multiple_import_column_sources_per_field.patch
@@ -1,0 +1,18 @@
+diff --git a/sites/all/modules/contrib/media_feeds/media_feeds.module b/sites/all/modules/contrib/media_feeds/media_feeds.module
+index 1d7926a58..dee205193 100644
+--- a/sites/all/modules/contrib/media_feeds/media_feeds.module
++++ b/sites/all/modules/contrib/media_feeds/media_feeds.module
+@@ -73,7 +73,12 @@ function media_feeds_set_target($source, $entity, $target, $values, $config = ar
+   list($target, $provider) = explode(':', $target, 2) + array(1 => 'MediaFeedsInternetProvider');
+ 
+   $field_info = field_info_field($target);
+-  $field = array(LANGUAGE_NONE => array());
++  // ensure we don't overwrite any existing values from other columns in the import which are writing to the same field
++  if (property_exists($entity, $target)) {
++    $field = $entity->{$target};
++  } else {
++    $field = array(LANGUAGE_NONE => array());
++  }
+ 
+   foreach ($values as $value) {
+     try {


### PR DESCRIPTION
This shows up when you have two media columns which are adding to a single media field. For example, "File attachments (Filename)" and "File attachments (URL)". If the columns appear in this order and you only put values in the "File attachments (Filename)" column then when the "File attachments (URL)" column is read after correctly reading the files from the first column, the second column's values overwrite it. If the second column is blank then you end up with nothing in your field.

Fixes https://github.com/NaturalHistoryMuseum/scratchpads2/issues/6062