### PR TITLE
Allow devs to override the docker compose config without a mess

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ scratchpads_twitter.ini
 .env
 .docker-sync
 nohup.out
+docker-compose.dev.yml


### PR DESCRIPTION
If you put your dev overrides in docker-compose.dev.yml then you won't have to skip them whenever committing.