### PR TITLE
Set latitude & longitude to null if empty string

### DIFF
--- a/sites/all/modules/custom/gm3/gm3_field/gm3_field.module
+++ b/sites/all/modules/custom/gm3/gm3_field/gm3_field.module
@@ -362,8 +362,8 @@ function _gm3_field_get_arrays_from_points_strings($value){
       $lat_lng = explode(",", $lat_lng[0]);
     }
     $lat_lng = array(
-      'latitude' => $lat_lng[0],
-      'longitude' => $lat_lng[1]
+      'latitude' => $lat_lng[0] == '' ? null : $lat_lng[0],
+      'longitude' => $lat_lng[1] == '' ? null : $lat_lng[1]
     );
     $items[] = $lat_lng;
   }


### PR DESCRIPTION
Fixes #6166.

If set to an empty string, the SQL query errors with `field_map_latitude truncated`.