### PR TITLE
Enable updating casing of contributors + keywords

### DIFF
--- a/sites/all/modules/contrib/biblio/includes/Parser.php
+++ b/sites/all/modules/contrib/biblio/includes/Parser.php
@@ -138,7 +138,7 @@ class HumanNameParser_Parser {
     $arr['prefix']    = $this->leadingInit;
     $arr['firstname'] = $this->first;
     $arr['nicknames'] = $this->nicknames;
-    $arr['initials']  = substr($this->middle, 0, 10);
+    $arr['initials']  = preg_replace('/(?<=\b[A-Za-z])[A-Za-z]+\s*/m', '', $this->middle);
     $arr['lastname']  = $this->last;
     $arr['suffix']    = $this->suffix;
     $arr['md5']       = md5(json_encode($arr));

--- a/sites/all/modules/contrib/biblio/includes/biblio.contributors.inc
+++ b/sites/all/modules/contrib/biblio/includes/biblio.contributors.inc
@@ -395,6 +395,16 @@ function _save_contributors(&$contributors, $nid, $vid, $update = FALSE) {
         $auth = biblio_get_contributor_by_name($author['name']);
         if (!empty($auth) && isset($auth->cid)) {
           $author['cid'] = $auth->cid;
+          // update capitalisation if necessary; spelling should be identical but capitalisation may differ
+          if ($auth->name != $author['name']) {
+            try {
+              $author = $name_parser->parseName($author);
+              biblio_update_contributor($author);
+            }
+            catch (Exception $e) {
+              // don't update the record then i guess
+            }
+          }
           $contributors[$key] = array_merge($author, (array)$auth);
         }
       }

--- a/sites/all/modules/contrib/biblio/includes/biblio.keywords.inc
+++ b/sites/all/modules/contrib/biblio/includes/biblio.keywords.inc
@@ -185,6 +185,17 @@ function biblio_insert_keywords($node, $update = FALSE) {
     }
     // Defend against duplicate, differently cased tags
     if (!isset($inserted[$kid])) {
+      // update casing
+      if ($kw->word != $word) {
+        try {
+          $kw = array('word' => trim($word));
+          $kw['kid'] = $kid;
+          biblio_save_keyword($kw);
+        }
+        catch (Exception $e) {
+          // ignore it
+        }
+      }
       db_merge('biblio_keyword')
         ->key(array('kid' => $kid, 'vid' => $node->vid))
         ->fields(


### PR DESCRIPTION
- allow users to correct the casing for contributors and keywords in literature items
- initialise middle names properly instead of just truncating them

Fixes #6159.