### PR TITLE
i18n taxonomy autocomplete includes TIDs

### DIFF
--- a/sites/all/modules/contrib/i18n/i18n_taxonomy/i18n_taxonomy.pages.inc
+++ b/sites/all/modules/contrib/i18n/i18n_taxonomy/i18n_taxonomy.pages.inc
@@ -125,7 +125,7 @@ function _i18n_taxonomy_autocomplete($langcode, $vids, $tags_typed = '') {
 
     $term_matches = array();
     foreach ($tags_return as $tid => $name) {
-      $n = $name;
+      $n = $name . ' [' . $tid . ']';
       // Term names containing commas or quotes must be wrapped in quotes.
       if (strpos($name, ',') !== FALSE || strpos($name, '"') !== FALSE) {
         $n = '"' . str_replace('"', '""', $name) . '"';


### PR DESCRIPTION
Avoids conflict between similar spellings (i.e. spellings considered the same by MySQL collation settings). Fixes #6149