### PR TITLE
Added <> to doi regex

### DIFF
--- a/sites/all/modules/contrib/biblio/modules/crossref/biblio_crossref.module
+++ b/sites/all/modules/contrib/biblio/modules/crossref/biblio_crossref.module
@@ -56,7 +56,7 @@ function biblio_crossref_form_biblio_node_form_submit($form, &$form_state) {
   $node_data = array();
   if (strlen($form_state['values']['doi_data'])) {
     // this regex matches "modern" crossref patterns, see here: https://www.crossref.org/blog/dois-and-matching-regular-expressions/
-    preg_match('/^.*?(10.\d{4,9}\/[-._;()\/:a-zA-Z0-9]+)$/i', $form_state['values']['doi_data'], $match);
+    preg_match('/^.*?(10.\d{4,9}\/[-._;()\/:a-zA-Z0-9<>]+)$/i', $form_state['values']['doi_data'], $match);
     if ($match) {
       $doi = $match[1];
       if (!($dup = biblio_crossref_check_doi($doi))) {


### PR DESCRIPTION
To account for unusual cases where < and > may be part of a valid DOI, e.g. `10.1577/1548-8675(2002)022<0208:tgctrt>2.0.co;2`.

Fixes #6192.