### PR TITLE
Don't set node_options values when building node type form

### DIFF
--- a/sites/all/modules/custom/scratchpads/scratchpads_tweaks/scratchpads_tweaks.module
+++ b/sites/all/modules/custom/scratchpads/scratchpads_tweaks/scratchpads_tweaks.module
@@ -790,9 +790,6 @@ function scratchpads_tweaks_field_widget_info_alter(&$info){
  */
 function scratchpads_tweaks_form_node_type_form_alter(&$form, &$form_state){
   // replace the element with its expanded items
-  $form['workflow']['node_options']['#value'] = drupal_map_assoc($form['workflow']['node_options']['#default_value']);
-  $form['workflow']['node_options']['#attributes'] = array();
-  $form['workflow']['node_options'] = form_process_checkboxes($form['workflow']['node_options']);
   $form['workflow']['node_options']['revision']['#description'] = t("Revisions let you track differences between multiple versions of a node. When enabled, all previous versions of a node will be visible under a new 'Revisions' tab in. Users will be able to view older versions of this node and editors will be able to revert the node to an older version.");
   $form['workflow']['node_options']['status']['#description'] = t('Select to make content visible to all users. If not selected content will only be visible through the administration menu.');
   $form['workflow']['node_options']['promote']['#description'] = t('Select to have content appearing on the front page of the site.');


### PR DESCRIPTION
I believe the call to form_process_checkboxes was added erroneously
and has no effect. The other two lines were added to fix bugs with
calling form_process_checkboxes here, and cause bug #6234