### PR TITLE
Fix the disappearing biblio fields bug

### DIFF
--- a/sites/all/modules/custom/scratchpads/scratchpads_biblio/scratchpads_biblio.module
+++ b/sites/all/modules/custom/scratchpads/scratchpads_biblio/scratchpads_biblio.module
@@ -6,11 +6,10 @@
 function scratchpads_biblio_form_node_form_alter(&$form, &$form_state, $form_id)
 {
 
-  if ($form_id == 'biblio_node_form' && arg(2) == 'clone') {
+  if (($form_id == 'biblio_node_form' && arg(2) == 'clone') || !isset($form_state['biblio_type'])) {
     $form_state['biblio_type'] = 'set biblio type so that we can save!';
   }
 
-  $form_state['biblio_type'] = 'set biblio type so that we can save!';
   $form['#validate'][] = 'scratchpads_biblio_form_node_form_validate';
 
 }


### PR DESCRIPTION
The `biblio_type` attribute of `form_state` was being [unset](https://github.com/NaturalHistoryMuseum/scratchpads2/blob/84cdc78fce7900ff43729c2b9136d1166d480fb4/sites/all/modules/custom/scratchpads/scratchpads_biblio/scratchpads_biblio.module#L13) basically as soon as it was being [set](https://github.com/NaturalHistoryMuseum/scratchpads2/blob/84cdc78fce7900ff43729c2b9136d1166d480fb4/sites/all/modules/contrib/biblio/biblio.module#L1497), meaning that the wrong set of tabs were [requested](https://github.com/NaturalHistoryMuseum/scratchpads2/blob/84cdc78fce7900ff43729c2b9136d1166d480fb4/sites/all/modules/contrib/biblio/biblio.module#L1226) when the form was refreshed (e.g. by previewing or adding media).

Fixes #6127, #6190, #6244, and probably others.