### PR TITLE
Set nontaxonomy uris

### DIFF
--- a/sites/all/modules/custom/scratchpads/scratchpads_species/scratchpads_species.module
+++ b/sites/all/modules/custom/scratchpads/scratchpads_species/scratchpads_species.module
@@ -1367,3 +1367,19 @@ function scratchpads_species_image_default_styles(){
     )
   );
 }
+
+/**
+ * Implements callback_entity_info_uri().
+ */
+function scratchpads_species_term_uri($term) {
+  if (scratchpads_species_term_is_biological_classification($term)) {
+    return array(
+      'path' => 'taxonomy/term/' . $term->tid,
+    );
+  }
+  else {
+    return array(
+      'path' => 'nontaxonomy/term/' . $term->tid,
+    );
+  }
+}

--- a/sites/all/modules/custom/tinytax/tinytax.theme.inc
+++ b/sites/all/modules/custom/tinytax/tinytax.theme.inc
@@ -159,7 +159,7 @@ function theme_tinytax_term($variables){
       'path' => file_create_url(drupal_get_path('module', 'tinytax') . '/images/leaf.gif')
     ));
   }
-  $term_uri = taxonomy_term_uri($variables['term']);
+  $term_uri = scratchpads_species_term_uri($variables['term']);
   $term_text = theme('scratchpads_species_name', array(
     'term' => $variables['term']
   ));


### PR DESCRIPTION
Would fix #6294.

- adds `scratchpads_species_term_uri` which sets the URL as normal (i.e. `taxonomy/term/$tid`) if term is in a bio classification but sets it to `nontaxonomy/term/$tid` for non-bio classifications
- replaced `taxonomy_term_uri` call in tinytax with call to new method, so trees get built with the correct URL