### PR TITLE
Set https = on now that we're behind the waf

### DIFF
--- a/sites/all/platform.settings.php
+++ b/sites/all/platform.settings.php
@@ -1,0 +1,4 @@
+<?php
+if ($_SERVER['HTTP_HOST'] != 'get.scratchpads.org') {
+  $_SERVER['HTTPS'] = 'on';
+}


### PR DESCRIPTION
This should fix all the https errors we've been seeing, e.g.:

- favicon's failing to load
- ajax failing to work in most places

_Note - I've already manually applied this change to the 2.9.17.1 platform._