### PR TITLE
Clear varnish cache on rebuild dwca

### DIFF
--- a/sites/all/modules/custom/dwcarchiver/dwcarchiver.rebuild.inc
+++ b/sites/all/modules/custom/dwcarchiver/dwcarchiver.rebuild.inc
@@ -37,6 +37,9 @@ function dwcarchiver_rebuild($dwcarchiver, $deliver = TRUE) {
       if ($deliver && !user_access('scratchpads team')) {
         drupal_set_message(t('The DwC-A has been rebuilt'));
       }
+      // Clear varnish cache
+      $dwc_uri = dwcarchiver_get_archive_uri($dwcarchiver);
+      varnish_expire_cache(array($dwc_uri));
     }
 
     if ($deliver) {


### PR DESCRIPTION
Fix for #6583 - clear dwca file from varnish cache. Updates code in [2.11.1](https://github.com/NaturalHistoryMuseum/scratchpads2/releases/tag/2.11.1) to not use hardcoded dwca file name, so this should work with custom dwca files.  